### PR TITLE
Fixing prepareDirectories to move all xls files to /tmp/{expected-dir}

### DIFF
--- a/prepareDirectories.sh
+++ b/prepareDirectories.sh
@@ -2,6 +2,7 @@
 
 prepareCommonDirs() {
 	mkdir /tmp/spreadsheets/
+	cp spreadsheets/*.xls /tmp/spreadsheets/
 	mkdir /tmp/serializedKnowledgeBase/
 }
 


### PR DESCRIPTION
Fixing prepareDirectories to move all xls files to /tmp/{expected-dir}
